### PR TITLE
added fix for pip upgrade issue

### DIFF
--- a/Basic/basicReport.py
+++ b/Basic/basicReport.py
@@ -26,6 +26,7 @@ except ImportError as error:
     time.sleep(10) 
     for i in req:
         try:
+            os.system('python3 pip install --upgrade pip')
             os.system('pip3 install {}'.format(i))
         except error:
             print('Error installing dependencies... ')


### PR DESCRIPTION
Fixed issue with having to update pip before pip installing matplotlib. Used to cause fatal error with pillows install but after upgrading pip first, it works